### PR TITLE
Restrict HTTP Error Intercept

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,25 +84,34 @@ app.use(function(req, res, next) {
 
 // development error handler
 // will print stacktrace
-if (app.get('env') === 'development') {
-    app.use(function(err, req, res, next) {
+
+app.use(function(err, req, res, next) {
+    if(err.name) {
+        if(err.name == 'ValidationError') {
+            res.status(400);
+            res.send({
+                message: err.errors
+            });
+        }
+    } else {
         res.status(err.status || 500);
         res.send({
             message: err.message,
-            error: err
+            error: {}
         });
-    });
-}
-
-// production error handler
-// no stacktraces leaked to user
-app.use(function(err, req, res, next) {
-    res.status(err.status || 500);
-    res.send({
-        message: err.message,
-        error: {}
-    });
+    }
 });
+
+//
+//// production error handler
+//// no stacktraces leaked to user
+//app.use(function(err, req, res, next) {
+//    res.status(err.status || 500);
+//    res.send({
+//        message: err.message,
+//        error: {}
+//    });
+//});
 
 
 module.exports = app;

--- a/public/javascript/app.js
+++ b/public/javascript/app.js
@@ -2,19 +2,21 @@
  * Created by matjames007 on 9/10/16.
  */
 
-angular.module('harvestv2', ["ngRoute", "harvestv2.services", "angular-table"]).config(['$routeProvider', '$locationProvider', function ($routeProvider, $locationProvider) {
-    $routeProvider.when('/', {templateUrl: '../partials/home.html', controller: 'UserCtrl'});
-    $routeProvider.when('/signin', {templateUrl: '../partials/signin.html', controller: 'UserLoginCtrl'});
-    $routeProvider.when('/signup', {templateUrl: '../partials/signup.html', controller: 'UserCtrl'});
-    $routeProvider.when('/confirmation', {templateUrl: '../partials/confirmation.html', controller: 'UserCtrl'});
-    $routeProvider.when('/dashboard', {templateUrl: '../partials/dashboard.html', controller: 'UserDashboardCtrl'});
-    $routeProvider.when('/profile', {templateUrl: '../partials/profile.html', controller: 'UserCtrl'});
-    $routeProvider.when('/activate/:token', {templateUrl: '../partials/signin.html', controller: 'UserLoginCtrl'});
-    $routeProvider.when('/admin', {templateUrl: '../partials/admin/dashboard.html', controller: 'AdminDashboardCtrl'});
-    $routeProvider.when('/admin/:entity', {templateUrl: '../partials/admin/dashboard-entity.html', controller: 'AdminDashboardCtrl'});
-    $routeProvider.when('/admin/:entity/logs', {templateUrl: '../partials/admin/dashboard-entity-logs.html', controller: 'AdminActivityCtrl'});
-    $routeProvider.when('/admin/:entity/roles', {templateUrl: '../partials/admin/dashboard-roles.html', controller: 'AdminRoleCtrl'});
-    $routeProvider.otherwise({redirectTo: '/'});
-}]).config(['$httpProvider',function($httpProvider) {
-    $httpProvider.interceptors.push('HTTPInterceptor');
-}]);
+angular.module('harvestv2', ["ngRoute", "harvestv2.services", "angular-table"])
+    .config(['$routeProvider', '$locationProvider', function ($routeProvider, $locationProvider) {
+        $routeProvider.when('/', {templateUrl: '../partials/home.html', controller: 'UserCtrl'});
+        $routeProvider.when('/signin', {templateUrl: '../partials/signin.html', controller: 'UserLoginCtrl'});
+        $routeProvider.when('/signup', {templateUrl: '../partials/signup.html', controller: 'UserCtrl'});
+        $routeProvider.when('/confirmation', {templateUrl: '../partials/confirmation.html', controller: 'UserCtrl'});
+        $routeProvider.when('/dashboard', {templateUrl: '../partials/dashboard.html', controller: 'UserDashboardCtrl'});
+        $routeProvider.when('/profile', {templateUrl: '../partials/profile.html', controller: 'UserCtrl'});
+        $routeProvider.when('/activate/:token', {templateUrl: '../partials/signin.html', controller: 'UserLoginCtrl'});
+        $routeProvider.when('/admin', {templateUrl: '../partials/admin/dashboard.html', controller: 'AdminDashboardCtrl'});
+        $routeProvider.when('/admin/:entity', {templateUrl: '../partials/admin/dashboard-entity.html', controller: 'AdminDashboardCtrl'});
+        $routeProvider.when('/admin/:entity/logs', {templateUrl: '../partials/admin/dashboard-entity-logs.html', controller: 'AdminActivityCtrl'});
+        $routeProvider.when('/admin/:entity/roles', {templateUrl: '../partials/admin/dashboard-roles.html', controller: 'AdminRoleCtrl'});
+        $routeProvider.otherwise({redirectTo: '/'});
+    }])
+    .config(['$httpProvider',function($httpProvider) {
+        $httpProvider.interceptors.push('HTTPInterceptor');
+    }]);

--- a/public/javascript/services.js
+++ b/public/javascript/services.js
@@ -13,7 +13,7 @@ var services = angular.module('harvestv2.services', ['ngResource']);
 services.factory('HTTPInterceptor', ['$q','$location', function($q,$location){
     return {
         responseError: function(response){
-            if(response.status == 400) {
+            if(response.status == 401) {
                 var encodedURL = encodeURIComponent($location.absUrl());
                 window.location = "#/signin?goTo=" + encodedURL;
                 return;

--- a/public/javascript/services.js
+++ b/public/javascript/services.js
@@ -16,7 +16,9 @@ services.factory('HTTPInterceptor', ['$q','$location', function($q,$location){
             if(response.status == 400) {
                 var encodedURL = encodeURIComponent($location.absUrl());
                 window.location = "#/signin?goTo=" + encodedURL;
+                return;
             }
+            return $q.reject(response);
         }
     };
 }]);

--- a/public/partials/common/system-modal.html
+++ b/public/partials/common/system-modal.html
@@ -1,0 +1,6 @@
+<div>
+    <h4 class="modal-title">{{info.title}}</h4>
+</div>
+<div>
+    {{info.message | json}}
+</div>

--- a/routes/common/auth-rules.js
+++ b/routes/common/auth-rules.js
@@ -16,7 +16,7 @@ exports.isAuthenticated = function (req, res, next) {
         return next();
     } else {
         var error = new Error("Authentication Necessary - Protected Resource");
-        error.status = 400;
+        error.status = 401;
         return next(error);
     }
 };

--- a/routes/user/user.js
+++ b/routes/user/user.js
@@ -15,7 +15,6 @@ var User = model.User,
     Log = model.Log,
     App = model.App;
 
-
 /**
  * Function used to send the user details back the application
  * only after successfully authenticating.  This is intended


### PR DESCRIPTION
The HTTP Interceptor should only be used to catch http status codes of 400.  Otherwise it should not interfere with existing error handling.