### PR TITLE
Update README.md to include waffle badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 #Harvest 2.0
-[![Stories in Ready](https://badge.waffle.io/slashroots/harvest-v2.svg?label=ready&title=Ready)](http://waffle.io/slashroots/harvest-v2)
-
+[![Stories in Ready](https://badge.waffle.io/slashroots/harvest-v2.svg?label=ready&title=Ready)](http://waffle.io/slashroots/harvest-v2) [![Build Status](https://travis-ci.org/slashroots/harvest-v2.svg?branch=master)](https://travis-ci.org/slashroots/harvest-v2)
 
 Developed using Node.js and the Express Framework
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 #Harvest 2.0
+[![Stories in Ready](https://badge.waffle.io/slashroots/harvest-v2.svg?label=ready&title=Ready)](http://waffle.io/slashroots/harvest-v2)
+
 
 Developed using Node.js and the Express Framework
 


### PR DESCRIPTION
I've added the waffle.io badge for this project to the README.md file. A waffle board has been created and updated to reflect current state of the project. It is accessible here: https://waffle.io/slashroots/harvest-v2