### PR TITLE
changing the homepage to the docs as requested in #105

### DIFF
--- a/models/db.js
+++ b/models/db.js
@@ -6,7 +6,7 @@
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
-mongoose.connect(process.env.MONGOLAB_URI);
+mongoose.connect(process.env.MONGOLAB_URI || "localhost:27017/mongodb");
 
 
 /**

--- a/models/db.js
+++ b/models/db.js
@@ -6,7 +6,7 @@
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
-mongoose.connect(process.env.MONGOLAB_URI || "localhost:27017/mongodb");
+mongoose.connect(process.env.MONGOLAB_URI);
 
 
 /**

--- a/public/javascript/app.js
+++ b/public/javascript/app.js
@@ -8,10 +8,11 @@
  */
 angular.module('harvestv2', ["ngRoute", "harvestv2.services", "angular-table", "angularCSS"])
     .config(['$routeProvider', '$locationProvider', function ($routeProvider, $locationProvider) {
-        $routeProvider.when('/', {
+        /*$routeProvider.when('/', {
             templateUrl: '../partials/home.html',
             controller: 'UserCtrl',
-            css: '/stylesheets/style.css'});
+            css: '/stylesheets/style.css'});*/
+        $routeProvider.when('/', {redirectTo: '/docs'});
         $routeProvider.when('/docs', {
             templateUrl: '../partials/docs.html',
             controller: 'DocsCtrl',


### PR DESCRIPTION
This pull request serves to fixes #105. The original route to the homepage was commented out, in case it should be used in the future, and another was set up to redirect to the `/docs` path.