### PR TITLE
Admin Dashboard User Applications Fix

### DIFF
--- a/routes/app/app-manager.js
+++ b/routes/app/app-manager.js
@@ -17,7 +17,6 @@ var logging = require('../../util/logging-util');
  */
 exports.getApplications = function(req, res, next) {
     App.find()
-        .where('us_app_user', req.user._id)
         .populate('us_app_user ap_app_role')
         .exec(function(err, docs) {
             if(err) {


### PR DESCRIPTION
This PR fixes issue #109 where the admin would only see their own apps on the Admin Dashboard instead of apps belonging to all users of the platform.