### PR TITLE
Form submission on both the dev dashboard and sign in pages now undergo validation form client side.

### DIFF
--- a/public/partials/dashboard.html
+++ b/public/partials/dashboard.html
@@ -101,10 +101,10 @@
                             <div class="row">
                                 <div class="col-md-12">
                                     <div class="">
-                                        <form>
+                                        <form id="appForm" data-toggle="validator" role="form" name="appForm" method="post" action="none" novalidate>
                                             <div class="form-group">
                                                 <label for="inputAppName">App Name</label>
-                                                <input ng-model="app.ap_app_name" type="text" class="form-control" id="inputAppName">
+                                                <input ng-model="app.ap_app_name" type="text" class="form-control" id="inputAppName" required>
                                             </div>
                                             <div class="form-group">
                                                 <label>Brief Description</label>
@@ -117,7 +117,7 @@
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                            <button type="button" ng-click="createApp()" class="btn btn-default drk-grey-btn" data-dismiss="modal">Submit</button>
+                            <button type="button" ng-click="createApp()" ng-disabled="appForm.$invalid" class="btn btn-success drk-grey-btn" data-dismiss="modal">Submit</button>
                         </div>
                     </div>
 

--- a/public/partials/signin.html
+++ b/public/partials/signin.html
@@ -17,7 +17,7 @@
                 <div class="sign-in form-wrap">
                     <h2 class="form-head text-center">Sign In to Your Account</h2>
                     <center><p><font color="#DB4947">These are required fields.</font></p></center>
-                    <form>
+                    <form id="signinForm"  data-toggle="validator" role="form" name="signinForm" method="post" action="none" novalidate>
                         <div class="form-group">
                             <label for="username"><font color="#DB4947">*</font> Username</label>
                             <input type="text" ng-model="credentials.username" class="form-control" id="username" placeholder="Username" required>
@@ -27,7 +27,7 @@
                             <input type="password" ng-model="credentials.password" class="form-control" id="inputPassword1" placeholder="Password" required>
                         </div>
                         <!--<button type="submit" class="btn btn-default btn-lg drk-grey-btn">Sign In</button>-->
-                        <a href="" ng-disabled="signupForm.$invalid" class="btn btn-default btn-lg drk-grey-btn" ng-click="login()">Sign In</a>
+                        <a href="" ng-disabled="signinForm.$invalid" class="btn btn-default btn-lg drk-grey-btn" ng-click="login()">Sign In</a>
                     </form>
                     <div class="form-links-wrap">
                         <ul class="form-links text-center">


### PR DESCRIPTION
When adding a new app, the 'submit' button will now b disabled until an app name is entered. This has also been implemented on the 'signin' page, so the 'submit' button will be disabled until BOTH the username and the password has been entered. 

This pull request fixes #54 