### PR TITLE
User Login Error Messages

### DIFF
--- a/public/javascript/controllers/user-ctrl.js
+++ b/public/javascript/controllers/user-ctrl.js
@@ -146,7 +146,7 @@ angular.module('harvestv2')
                     }
                 }, function(error) {
                     $scope.success = false;
-                    $scope.loginScreenNotification = "We were unable to log you in! Please check your credentials!";
+                    $scope.loginScreenNotification = "We were unable to log you in! Please check your credentials and ensure that you have activated your account!";
                 });
             };
 

--- a/public/javascript/services.js
+++ b/public/javascript/services.js
@@ -13,7 +13,11 @@ var services = angular.module('harvestv2.services', ['ngResource']);
 services.factory('HTTPInterceptor', ['$q','$location', function($q,$location){
     return {
         responseError: function(response){
-            if(response.status == 401) {
+            /*
+             I have disabled the HTTP interceptor for 401 errors resulting from the 'signin' page because it breaks the error messages I had implemented.
+             It was intended to redirect unauthenticated users from pages they should not be accessing to the signin page and it will continue to do that.
+             */
+            if(response.status == 401 && $location.path() !== '/signin') {
                 var encodedURL = encodeURIComponent($location.absUrl());
                 window.location = "#/signin?goTo=" + encodedURL;
                 return;


### PR DESCRIPTION
I have disabled the HTTP interceptor for 401 errors resulting from the 'signin' page because it breaks the error messages I had implemented previously. I believe the HTTP Interceptor was intended to redirect unauthenticated users from pages they should not be accessing to the signin page and it will continue to do that.

