### PR TITLE
removed an instance of the authentication definition that was missed when purging them.

### DIFF
--- a/public/docs/swagger.yaml
+++ b/public/docs/swagger.yaml
@@ -383,11 +383,6 @@ paths:
                     description: Unauthorized
                 500:
                     description: Internal Server Error
-securityDefinitions:             #ASK NICK HOW WE'D ACCESS/PASS API KEY AND AUTH TOKEN
-    api_key:
-        type: apiKey
-        name: access_token
-        in: header
 definitions:
     Crop:
         type: object

--- a/public/docs/swagger.yaml
+++ b/public/docs/swagger.yaml
@@ -388,13 +388,6 @@ securityDefinitions:             #ASK NICK HOW WE'D ACCESS/PASS API KEY AND AUTH
         type: apiKey
         name: access_token
         in: header
-    #access_key:
-        #type: oauth2
-        #authorizationUrl: harvest-api-staging.herokuapp.com/api
-        #flow: implicit
-        #scopes:      #ASK NICK WHAT SCOPES WE ARE USING
-            #write_pets: modify pets in your account
-            #read_pets: read your pets
 definitions:
     Crop:
         type: object


### PR DESCRIPTION
The authentication definition should no longer show at the beginning of the documentation.