### PR TITLE
Documentation Fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "font-awesome": "^4.6.3",
     "html5shiv": "^3.7.3",
     "respond": "^1.4.2",
-    "redoc": "^1.3.2",
+    "redoc": "1.3.2",
     "swagger-ui": "^2.2.4",
     "angular-resource": "~1.5.8",
     "angular-route": "~1.5.8",


### PR DESCRIPTION
Setting us back to redoc version 1.3.2 for now. The new version of redoc completely broke the documentation. I'll take a closer look at it in future to see why and possibly submit a bug report on the repo for the redoc library but for now I just need to get this fixed so that RADA can proceed.