### PR TITLE
Email RADA on User Signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Role and Permission Management - Access Control List (ACL)
     *   SMTP_USER
     *   SMTP_PASSWORD
     *   SMTP_PORT
+    *   RADA_HARVEST_EMAIL_ADDRESS

--- a/routes/user/user.js
+++ b/routes/user/user.js
@@ -286,6 +286,14 @@ exports.createUser = function(req, res, next) {
                         res.send(user);
                     }
                 });
+            common.sendEmail("harvestapi@rada.gov.jm", "New HarvestAPI User", "A new user with email address " + user.us_email_address + " has signed up to use the API.", function (error, info) {
+                if (error) {
+                    logging.accessLogger(user,req.url,logging.LOG_LEVEL_USER_ACTIVITY, "An email was not sent to RADA when this account was created!",true, user);
+                }
+                else {
+                    logging.accessLogger(user, req.url, logging.LOG_LEVEL_USER_ACTIVITY, "An email was successfully sent to RADA when this account was created!", true, user);
+                }
+            })
         }
     });
 };

--- a/routes/user/user.js
+++ b/routes/user/user.js
@@ -286,7 +286,7 @@ exports.createUser = function(req, res, next) {
                         res.send(user);
                     }
                 });
-            common.sendEmail("harvestapi@rada.gov.jm", "New HarvestAPI User", "A new user with email address " + user.us_email_address + " has signed up to use the API.", function (error, info) {
+            common.sendEmail(process.env.RADA_HARVEST_EMAIL_ADDRESS, "New HarvestAPI User", "A new user with email address " + user.us_email_address + " has signed up to use the API.", function (error, info) {
                 if (error) {
                     logging.accessLogger(user,req.url,logging.LOG_LEVEL_USER_ACTIVITY, "An email was not sent to RADA when this account was created!",true, user);
                 }


### PR DESCRIPTION
This branch implements a notification email to RADA when a new user signs up to use the API. It's sent to harvestapi@rada.gov.jm and it writes a log to indicate success or failure - similar to what was done for the email that we send to the users themselves.